### PR TITLE
Fix typo in fast-forward keycode

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -346,8 +346,8 @@ export const KEY_CODES = [
     value: 'play_or_pause',
   },
   {
-    label: 'Fastfoward / Next',
-    value: 'fastforwad',
+    label: 'Fastforward / Next',
+    value: 'fastforward',
   },
   {
     label: 'Mute',


### PR DESCRIPTION
I ran into this when making mappings for media controls. Play/Pause and Rewind/Previous were working, but Fastforward/Next wasn't due to a typo in the keycode.