### PR TITLE
Fix the assumption that modifiers is always an array.

### DIFF
--- a/src/components/MainForm.tsx
+++ b/src/components/MainForm.tsx
@@ -154,7 +154,7 @@ const parseToObject = (toObject: IToEventDefinition): any => {
   if (typeof _to.key_code === 'object') {
     _to.key_code = parseKey(toObject.key_code);
   }
-  if (_to.modifiers?.length) {
+  if (Array.isArray(_to.modifiers) && _to.modifiers.length) {
     _to.modifiers = parseKeys(_to.modifiers);
   }
   return _to;


### PR DESCRIPTION
Apparently, the modifiers does not have to be objects or arrays, but string is also accepted. This change fixes the assumption that having a truthy length implies the object is an array. When it is a string, this does not hold and breaks it.

You can reproduce the existing code failing with [this](https://raw.githubusercontent.com/anacierdem/MacWinKeys/master/KarabinerElementsRule.json) configuration.